### PR TITLE
feat: fix: increase 'tryMax' 5 -> 6 to attempt score sending once more

### DIFF
--- a/src/BokutachiHook.cpp
+++ b/src/BokutachiHook.cpp
@@ -195,7 +195,7 @@ static ExtendedCaps GetCaps() {
 
 static void SendScore(const std::string reqBody, const std::string songName, bool isDan)
 {
-	constexpr const int tryMax = 5;
+	constexpr const int tryMax = 6;
 	int tryCount = 1;
 	while (tryCount <= tryMax) {
 		cpr::Response r = cpr::Post(cpr::Url{ isDan ? urlDan : url },


### PR DESCRIPTION
Sleeping is done for at most 4^(tryMax-1) seconds, while it was expected to be done for 4^tryMax seconds.
This led to too small sleep time before the last attempt, 4^1×(4^4−1)/(4^1−1)=340 seconds=5+2/3 minutes.
This change lets the code sleep once more, adding an additional 4^5=1024 seconds=~17 minutes before a score is discarded forever.